### PR TITLE
feat: Add flag to the provider arguments to allow consumers to skip ssl verification on the influx client.

### DIFF
--- a/docs/data-sources/bucket.md
+++ b/docs/data-sources/bucket.md
@@ -14,10 +14,10 @@ Lookup a Bucket in InfluxDB2.
 
 ```terraform
 data "influxdb-v2_bucket" "bucket" {
-  name = "newName"
+  name = "testbucket"
 }
 
-output "influxdb-v2_bucket4" {
+output "influxdb-v2_bucket" {
   value = data.influxdb-v2_bucket.bucket
 }
 
@@ -58,5 +58,3 @@ Read-Only:
 - `every_seconds` (Number)
 - `shard_group_duration_seconds` (Number)
 - `type` (String)
-
-

--- a/docs/data-sources/organization.md
+++ b/docs/data-sources/organization.md
@@ -14,7 +14,7 @@ Lookup an Organization in InfluxDB2.
 
 ```terraform
 data "influxdb-v2_organization" "organization" {
-  name = "testorg"
+  name = "my-org"
 }
 
 output "influxdb-v2_organization_id" {
@@ -65,5 +65,3 @@ terraform {
 - `description` (String) The description of the Organization.
 - `updated_at` (String) The string time that the Organization was last updated.
 - `updated_timestamp` (Number) The timestamp that the Organization was last updated.
-
-

--- a/docs/data-sources/ready.md
+++ b/docs/data-sources/ready.md
@@ -27,5 +27,3 @@ output "influxdb-v2_ready" {
 
 - `id` (String) The ID of this resource.
 - `output` (Map of String)
-
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,8 +14,9 @@ description: |-
 
 ```terraform
 provider "influxdb-v2" {
-  url  = "http://localhost:8086"    # changeme
-  token = "WLCq15HS_zugineJalPUqxTxxBKK7IluEseKR0rD3-2CfHBdS0BguLHGEaXRnJ2p080EdTsx9yKq1kFnLnSaxA==" # changeme
+  host  = "http://localhost:8086"    # changeme
+  token = "super-secret-admin-token" # changeme
+  skip_ssl_verify = false            # default
 }
 ```
 
@@ -24,5 +25,6 @@ provider "influxdb-v2" {
 
 ### Optional
 
+- `skip_ssl_verify` (Boolean) skip ssl verify on connection
 - `token` (String, Sensitive)
 - `url` (String)

--- a/docs/resources/bucket.md
+++ b/docs/resources/bucket.md
@@ -14,7 +14,7 @@ description: |-
 
 ```terraform
 locals {
-  org_id = "ed2e6b93c8396828"
+  org_id = "example_org_id"
 }
 
 resource "influxdb-v2_bucket" "example_bucket" {


### PR DESCRIPTION
For Influx V1 the Terraform provider(s) provide the ability for consumers to choose to skip SSL verification when the Influx client is communicating with the database ([v1](https://registry.terraform.io/providers/DrFaust92/influxdb/latest/docs)).

This is useful when you are using self signed certificates with your Influx database and do not want to or cannot add the public certificates to the instances that consume from the database. Without being able to skip SSL verification in these use cases practicing infrastructure as code configuration of you Influx databases is difficult to impossible.