### PR TITLE
fix: remove password from resource output

### DIFF
--- a/influxdbv2/resource_create_legacy_authorization.go
+++ b/influxdbv2/resource_create_legacy_authorization.go
@@ -32,8 +32,9 @@ func ResourceLegacyAuthorization() *schema.Resource {
 				Required: true,
 			},
 			"password": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
 			},
 			"permissions": {
 				Type:     schema.TypeSet,
@@ -122,7 +123,6 @@ func resourceLegacyAuthorizationCreate(d *schema.ResourceData, m interface{}) er
 	if err != nil {
 		return err
 	}
-	err = d.Set("password", password)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR stops the password from being set on the resource state, it also marks it as sensitive as an incoming parameter.