### PR TITLE
feat: stop error state when resource does not exist

### DIFF
--- a/influxdbv2/resource_create_authorization.go
+++ b/influxdbv2/resource_create_authorization.go
@@ -129,22 +129,27 @@ func resourceAuthorizationRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return fmt.Errorf("error getting authorization: %v", err)
 	}
-	authorizations := getAuthorizationsById(result, d.Id())
+	found, authorization := getAuthorizationsById(result, d.Id())
 
-	err = d.Set("status", authorizations.Status)
+	if !found {
+		d.SetId("")
+		return nil
+	}
+
+	err = d.Set("status", authorization.Status)
 	if err != nil {
 		return err
 	}
-	err = d.Set("user_id", authorizations.UserID)
+	err = d.Set("user_id", authorization.UserID)
 	if err != nil {
 		return err
 	}
-	err = d.Set("user_org_id", authorizations.OrgID)
+	err = d.Set("user_org_id", authorization.OrgID)
 	if err != nil {
 		return err
 	}
-	if *authorizations.Token != "redacted" {
-		err = d.Set("token", authorizations.Token)
+	if *authorization.Token != "redacted" {
+		err = d.Set("token", authorization.Token)
 		if err != nil {
 			return err
 		}
@@ -197,12 +202,11 @@ func getPermissions(input interface{}) []domain.Permission {
 	return result
 }
 
-func getAuthorizationsById(input *[]domain.Authorization, id string) domain.Authorization {
-	result := domain.Authorization{}
+func getAuthorizationsById(input *[]domain.Authorization, id string) (bool, domain.Authorization) {
 	for _, authorization := range *input {
 		if *authorization.Id == id {
-			result = authorization
+			return true, authorization
 		}
 	}
-	return result
+	return false, domain.Authorization{}
 }

--- a/influxdbv2/resource_create_authorization_test.go
+++ b/influxdbv2/resource_create_authorization_test.go
@@ -60,6 +60,7 @@ func TestAccAuthorization(t *testing.T) {
 					deleteAuth(authorizationIdOnCreate)
 				},
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("influxdb-v2_authorization.acctest", "id"),
 					checkResourceHasBeenReplaced("influxdb-v2_authorization.acctest", &authorizationIdOnCreate),
 				),
 			},

--- a/influxdbv2/resource_create_authorization_test.go
+++ b/influxdbv2/resource_create_authorization_test.go
@@ -11,6 +11,8 @@ import (
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
 )
 
+var authorizationIdOnCreate string
+
 func TestAccAuthorization(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -20,6 +22,11 @@ func TestAccAuthorization(t *testing.T) {
 			{
 				Config: testAccCreateAuthorization(),
 				Check: resource.ComposeTestCheckFunc(
+					func(s *terraform.State) error {
+						id := extractIdForResource(s, "influxdb-v2_authorization.acctest")
+						authorizationIdOnCreate = id
+						return nil
+					},
 					resource.TestCheckResourceAttr("influxdb-v2_authorization.acctest", "org_id", os.Getenv("INFLUXDB_V2_ORG_ID")),
 					resource.TestCheckResourceAttr("influxdb-v2_authorization.acctest", "description", "Acceptance test token"),
 					resource.TestCheckResourceAttr("influxdb-v2_authorization.acctest", "status", "inactive"),
@@ -42,7 +49,18 @@ func TestAccAuthorization(t *testing.T) {
 					resource.TestCheckResourceAttrSet("influxdb-v2_authorization.acctest", "token"),
 					resource.TestCheckResourceAttr("influxdb-v2_authorization.acctest", "org_id", os.Getenv("INFLUXDB_V2_ORG_ID")),
 					// permissions is a complex array... we'll just check it has the correct length
-					resource.TestCheckResourceAttr("influxdb-v2_authorization.acctest", "permissions.#", "1"),
+					resource.TestCheckResourceAttr("influxdb-v2_authorization.acctest", "permissions.#", "2"),
+				),
+			},
+			{
+				// This test is designed to prove that the provider no longer errors when asked to read a resource that doesn't exist.
+				// The desired approach is to signal to terraform that the resource cannot be found so that the plan is to recreate it.
+				Config: testAccUpdateAuthorization(),
+				PreConfig: func() {
+					deleteAuth(authorizationIdOnCreate)
+				},
+				Check: resource.ComposeTestCheckFunc(
+					checkResourceHasBeenReplaced("influxdb-v2_authorization.acctest", &authorizationIdOnCreate),
 				),
 			},
 		},
@@ -89,6 +107,14 @@ resource "influxdb-v2_authorization" "acctest" {
             type = "buckets"
         }
     }
+    permissions {
+        action = "write"
+        resource {
+            id = "` + os.Getenv("INFLUXDB_V2_BUCKET_ID") + `"
+            org_id = "` + os.Getenv("INFLUXDB_V2_ORG_ID") + `"
+            type = "buckets"
+        }
+    }
 }
 `
 }
@@ -105,4 +131,15 @@ func testAccAuthorizationDestroyed(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func deleteAuth(id string) {
+	influx := influxdb2.NewClient(
+		os.Getenv("INFLUXDB_V2_URL"),
+		os.Getenv("INFLUXDB_V2_TOKEN"),
+	)
+	err := influx.AuthorizationsAPI().DeleteAuthorizationWithID(context.Background(), id)
+	if err != nil {
+		panic(fmt.Sprintf("Cannot delete authorization: %v", err))
+	}
 }

--- a/influxdbv2/resource_create_buckets.go
+++ b/influxdbv2/resource_create_buckets.go
@@ -101,6 +101,11 @@ func resourceBucketRead(d *schema.ResourceData, m interface{}) error {
 	influx := m.(meta).influxsdk
 	result, err := influx.BucketsAPI().FindBucketByID(context.Background(), d.Id())
 	if err != nil {
+		notFoundError := "not found: bucket not found"
+		if err.Error() == notFoundError {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("error getting bucket: %v", err)
 	}
 

--- a/influxdbv2/resource_create_buckets_test.go
+++ b/influxdbv2/resource_create_buckets_test.go
@@ -75,6 +75,7 @@ func TestAccCreateBucket(t *testing.T) {
 					deleteBucket("acctest")
 				},
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("influxdb-v2_bucket.acctest", "id"),
 					checkResourceHasBeenReplaced("influxdb-v2_bucket.acctest", &bucketIdOnCreate),
 				),
 			},

--- a/influxdbv2/resource_create_buckets_test.go
+++ b/influxdbv2/resource_create_buckets_test.go
@@ -11,6 +11,8 @@ import (
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
 )
 
+var bucketIdOnCreate string
+
 func TestAccCreateBucket(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -20,6 +22,11 @@ func TestAccCreateBucket(t *testing.T) {
 			{
 				Config: testAccCreateBucket(),
 				Check: resource.ComposeTestCheckFunc(
+					func(s *terraform.State) error {
+						id := extractIdForResource(s, "influxdb-v2_bucket.acctest")
+						bucketIdOnCreate = id
+						return nil
+					},
 					resource.TestCheckResourceAttr(
 						"influxdb-v2_bucket.acctest",
 						"org_id",
@@ -58,6 +65,17 @@ func TestAccCreateBucket(t *testing.T) {
 						"influxdb-v2_bucket.acctest",
 						"type",
 					),
+				),
+			},
+			{
+				// This test is designed to prove that the provider no longer errors when asked to read a resource that doesn't exist.
+				// The desired approach is to signal to terraform that the resource cannot be found so that the plan is to recreate it.
+				Config: testAccCreateBucket(),
+				PreConfig: func() {
+					deleteBucket("acctest")
+				},
+				Check: resource.ComposeTestCheckFunc(
+					checkResourceHasBeenReplaced("influxdb-v2_bucket.acctest", &bucketIdOnCreate),
 				),
 			},
 			{
@@ -164,4 +182,20 @@ func testAccBucketDestroyed(s *terraform.State) error {
 		return fmt.Errorf("Cannot read bucket list")
 	}
 	return nil
+}
+
+func deleteBucket(name string) {
+	influx := influxdb2.NewClient(
+		os.Getenv("INFLUXDB_V2_URL"),
+		os.Getenv("INFLUXDB_V2_TOKEN"),
+	)
+	result, err := influx.BucketsAPI().FindBucketByName(context.Background(), name)
+	if err != nil {
+		panic("Cannot find bucket")
+	}
+
+	err = influx.BucketsAPI().DeleteBucket(context.Background(), result)
+	if err != nil {
+		panic("Cannot delete bucket")
+	}
 }

--- a/influxdbv2/resource_create_dbrp_mapping.go
+++ b/influxdbv2/resource_create_dbrp_mapping.go
@@ -97,6 +97,11 @@ func resourceDBRPMappingRead(d *schema.ResourceData, m interface{}) error {
 		},
 	})
 	if err != nil {
+		notFoundError := "not found: unable to find DBRP"
+		if err.Error() == notFoundError {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("error getting dbrp: %v", err)
 	}
 

--- a/influxdbv2/resource_create_dbrp_mapping_test.go
+++ b/influxdbv2/resource_create_dbrp_mapping_test.go
@@ -45,6 +45,7 @@ func TestAccDBRPMapping(t *testing.T) {
 					deleteDBRP(dbrpIdOnCreate)
 				},
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("influxdb-v2_dbrp_mapping.acctest", "id"),
 					checkResourceHasBeenReplaced("influxdb-v2_dbrp_mapping.acctest", &dbrpIdOnCreate),
 				),
 			},

--- a/influxdbv2/resource_create_legacy_authorization.go
+++ b/influxdbv2/resource_create_legacy_authorization.go
@@ -151,6 +151,11 @@ func resourceLegacyAuthorizationRead(d *schema.ResourceData, m interface{}) erro
 	password := d.Get("password").(string)
 
 	authorization, err := influx.GetLegacyAuthorizationsIDWithResponse(context.Background(), d.Id(), &GetLegacyAuthorizationsIDParams{})
+	if authorization.StatusCode() == 404 {
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil || authorization.StatusCode() != 200 {
 		return fmt.Errorf("error getting authorization: %v", err)
 	}

--- a/influxdbv2/resource_create_legacy_authorization_test.go
+++ b/influxdbv2/resource_create_legacy_authorization_test.go
@@ -72,6 +72,7 @@ func TestAccLegacyAuthorization(t *testing.T) {
 					deleteLegacyAuthorization(legacyAuthIdOnCreate)
 				},
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("influxdb-v2_legacy_authorization.acctest", "id"),
 					checkResourceHasBeenReplaced("influxdb-v2_legacy_authorization.acctest", &legacyAuthIdOnCreate),
 				),
 			},

--- a/influxdbv2/resource_create_legacy_authorization_test.go
+++ b/influxdbv2/resource_create_legacy_authorization_test.go
@@ -175,7 +175,7 @@ func findResourceInState(s *terraform.State, name string) *terraform.InstanceSta
 func checkResourceHasBeenReplaced(name string, oid *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if id := extractIdForResource(s, name); id == *oid {
-			return fmt.Errorf("idd should have changed but it is still %s", id)
+			return fmt.Errorf("id should have changed but it is still %s", id)
 		}
 		return nil
 	}

--- a/influxdbv2/resource_create_legacy_authorization_test.go
+++ b/influxdbv2/resource_create_legacy_authorization_test.go
@@ -155,28 +155,3 @@ func testAccLegacyAuthorizationDestroyed(s *terraform.State) error {
 
 	return nil
 }
-
-func extractIdForResource(s *terraform.State, name string) string {
-	is := findResourceInState(s, name)
-	v, _ := is.Attributes["id"]
-	return v
-}
-
-func findResourceInState(s *terraform.State, name string) *terraform.InstanceState {
-	ms := s.RootModule()
-	rs, ok := ms.Resources[name]
-	if !ok {
-		return nil
-	}
-	is := rs.Primary
-	return is
-}
-
-func checkResourceHasBeenReplaced(name string, oid *string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if id := extractIdForResource(s, name); id == *oid {
-			return fmt.Errorf("id should have changed but it is still %s", id)
-		}
-		return nil
-	}
-}

--- a/influxdbv2/resource_create_organization.go
+++ b/influxdbv2/resource_create_organization.go
@@ -71,6 +71,11 @@ func resourceOrganizationRead(d *schema.ResourceData, m interface{}) error {
 	result, err := influx.OrganizationsAPI().
 		FindOrganizationByID(context.Background(), d.Id())
 	if err != nil {
+		notFoundError := "not found: organization not found"
+		if err.Error() == notFoundError {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("error getting organization: %v", err)
 	}
 	err = d.Set("name", result.Name)

--- a/influxdbv2/test_helpers.go
+++ b/influxdbv2/test_helpers.go
@@ -1,0 +1,33 @@
+package influxdbv2
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func extractIdForResource(s *terraform.State, name string) string {
+	is := findResourceInState(s, name)
+	v, _ := is.Attributes["id"]
+	return v
+}
+
+func findResourceInState(s *terraform.State, name string) *terraform.InstanceState {
+	ms := s.RootModule()
+	rs, ok := ms.Resources[name]
+	if !ok {
+		return nil
+	}
+	is := rs.Primary
+	return is
+}
+
+func checkResourceHasBeenReplaced(name string, oid *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if id := extractIdForResource(s, name); id == *oid {
+			return fmt.Errorf("id should have changed but it is still %s", id)
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
This PR stops resources erroring when they cannot read the requested resource by id, instead they will now surface this state to terraform by setting the id to `""`. An alternative approach would be implementing the Exists method but outcome would be the same.

This will now allow terraform to plan a recreation of the resource and terraform users to decide what to do with that plan.